### PR TITLE
allow one to set email fields via init args

### DIFF
--- a/lib/Email/Stuffer.pm
+++ b/lib/Email/Stuffer.pm
@@ -180,8 +180,9 @@ Creates a new, empty, Email::Stuffer object.
 =cut
 
 sub new {
-	my $class = ref $_[0] || $_[0];
-
+	my $proto = shift;
+	my $class = ref $proto || $proto;
+	my %args = (ref($_[0]) && ref($_[0]) eq 'HASH') ? %$_[0] : @_;
 	my $self = bless {
 		parts      => [],
 		email      => Email::MIME->create(
@@ -189,6 +190,12 @@ sub new {
 			parts  => [],
 			),
 		}, $class;
+
+	foreach my $init_arg (keys %args) {
+		if($self->can($init_arg)) {
+			$self->$init_arg($args{$init_arg});
+		}
+	}
 
 	$self;
 }

--- a/t/init-arg.t
+++ b/t/init-arg.t
@@ -1,0 +1,10 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 1;
+use Email::Stuffer;
+
+my $to = 'me@email.com';
+my $stuffer = Email::Stuffer->new(to=>$to);
+is( $stuffer->email->header('To'), $to, 'init-arg "to" sets To header' );


### PR DESCRIPTION
This is a patch that lets you set up the email fields via ->new(%args) or ->new(\%args).  This is handy if you are (for example) using this as a Catalyst model and want to setup some fields defaulted from config.  For example in Catalyst I tend to want to set the 'transport' via configuration so I can set the transport to "Print' in development and a real email queue in production.

Let me know what you think, thanks for having such a clear module available for when people need to email and don't have time to master the details!