### PR TITLE
Make addresses with 'Umlaute' work by converting them to ascii

### DIFF
--- a/lib/Email/Stuffer.pm
+++ b/lib/Email/Stuffer.pm
@@ -170,6 +170,7 @@ use Email::MIME 1.920      ();
 use Email::MIME::Creator   ();
 use Email::Sender::Simple  ();
 use Module::Runtime        qw(require_module);
+use Net::IDN::Encode       qw(email_to_ascii);
 
 #####################################################################
 # Constructor and Accessors
@@ -277,7 +278,7 @@ Sets the To: header in the email
 sub to {
 	my $self = shift()->_self;
 	Carp::croak("to is a required field") unless defined $_[0];
-	$self->{email}->header_str_set(To => join(q{, }, @_));
+	$self->{email}->header_str_set(To => join(q{, }, map { email_to_ascii $_ } @_));
 	return $self;
 }
 
@@ -290,7 +291,7 @@ Sets the From: header in the email
 sub from {
 	my $self = shift()->_self;
 	Carp::croak("from is a required field") unless defined $_[0];
-	$self->{email}->header_str_set(From => shift);
+	$self->{email}->header_str_set(From => email_to_ascii shift);
 	return $self;
 }
 
@@ -302,7 +303,7 @@ Sets the Cc: header in the email
 
 sub cc {
 	my $self = shift()->_self;
-	$self->{email}->header_str_set(Cc => join(q{, }, @_));
+	$self->{email}->header_str_set(Cc => join(q{, }, map { email_to_ascii $_ } @_));
 	return $self;
 }
 
@@ -314,7 +315,7 @@ Sets the Bcc: header in the email
 
 sub bcc {
 	my $self = shift()->_self;
-	$self->{email}->header_str_set(Bcc => join(q{, }, @_));
+	$self->{email}->header_str_set(Bcc => join(q{, }, map { email_to_ascii $_ } @_));
 	return $self;
 }
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use File::Spec::Functions ':ALL';
 
-use Test::More tests => 62;
+use Test::More tests => 66;
 use Test::Fatal;
 use Email::Stuffer;
 
@@ -126,5 +126,18 @@ $error = exception { Email::Stuffer::_slurp( 'no such file' ) };
 like $error,
     qr/\Aerror opening no such file: \Q$enoent/,
     '_slurp croaks when passed a bad filename';
+
+# Set a To, From, Cc and BCc name and check if ascii
+$rv = $Stuffer->to('adam@äli.as');
+is( $Stuffer->email->header('To'),   'adam@xn--li-dda5w.as', '->To sets To header'     );
+
+$rv->from('adam@äli.as');
+is( $Stuffer->email->header('From'), 'adam@xn--li-dda5w.as', '->From sets From header' );
+
+$rv->cc  ('adam@äli.as');
+is( $Stuffer->email->header('Cc'),   'adam@xn--li-dda5w.as', '->Cc sets From header'   );
+
+$rv->bcc ('adam@äli.as');
+is( $Stuffer->email->header('BCc'),  'adam@xn--li-dda5w.as', '->BCc sets From header'  );
 
 1;


### PR DESCRIPTION
Support addresses with 'Umlaute' like 'ü', 'ö', 'ä' by converting them to ascii before setting the header