### PR TITLE
Indicate to, cc, and bcc methods can take a list

### DIFF
--- a/lib/Email/Stuffer.pm
+++ b/lib/Email/Stuffer.pm
@@ -268,7 +268,7 @@ sub header {
 	return $self;
 }
 
-=method to $address
+=method to @addresses
 
 Sets the To: header in the email
 
@@ -294,7 +294,7 @@ sub from {
 	return $self;
 }
 
-=method cc $address
+=method cc @addresses
 
 Sets the Cc: header in the email
 
@@ -306,7 +306,7 @@ sub cc {
 	return $self;
 }
 
-=method bcc $address
+=method bcc @addresses
 
 Sets the Bcc: header in the email
 


### PR DESCRIPTION
Make it clear that the to, cc, and bcc methods can be given a list of email addresses.