### PR TITLE
Let `transport` be the first method in the chain

### DIFF
--- a/lib/Email/Stuffer.pm
+++ b/lib/Email/Stuffer.pm
@@ -605,7 +605,7 @@ an L<Email::Sender::Transport> object) and it will be used as is.
 =cut
 
 sub transport {
-  my $self = shift;
+  my $self = shift()->_self;
 
   if ( @_ ) {
     # Change the transport


### PR DESCRIPTION
`Email::Stuffer->from(...)->to(...)->etc->send` works fine

`Email::Stuffer->transport(...)->from(...)->to(...)->etc->send` dies:

`Can't use string ("Email::Stuffer") as a HASH ref while "strict refs" in use at Email/Stuffer.pm line 613.`

I figured there's no particular reason why `transport` should be different here.