### PR TITLE
Changed the order of param validation for method from() and reply_to().

### DIFF
--- a/lib/Email/Stuffer.pm
+++ b/lib/Email/Stuffer.pm
@@ -294,6 +294,9 @@ Sets the To: header in the email
 sub _assert_addr_list_ok {
   my ($self, $header, $allow_empty, $list) = @_;
 
+  Carp::croak('missing required header')
+    unless $header;
+
   Carp::croak("$header is a required field")
     unless $allow_empty or @$list;
 
@@ -321,8 +324,8 @@ Sets the From: header in the email
 
 sub from {
   my $self = shift()->_self;
-  $self->_assert_addr_list_ok(from => 0 => \@_);
   Carp::croak("only one address is allowed in the from header") if @_ > 1;
+  $self->_assert_addr_list_ok(from => 0 => \@_);
   $self->{email}->header_str_set(From => shift);
   return $self;
 }
@@ -335,8 +338,8 @@ Sets the Reply-To: header in the email
 
 sub reply_to {
   my $self = shift()->_self;
-  $self->_assert_addr_list_ok('reply-to' => 0 => \@_);
   Carp::croak("only one address is allowed in the reply-to header") if @_ > 1;
+  $self->_assert_addr_list_ok('reply-to' => 0 => \@_);
   $self->{email}->header_str_set('Reply-To' => shift);
   return $self;
 }


### PR DESCRIPTION
Hi @rjbs 

Please review the PR.
This propose change in order of param validation to method from() and reply_to(). As in these methods we only allow one address i.e. one member list. Therefore no point calling heavy duty _assert_addr_list_ok() and then checking we have one or more addresses. It would be better, in my humble opinion, check the list count and call the method _assert_addr_list_ok().

Many Thanks.
Best Regards,
Mohammad S Anwar.